### PR TITLE
Relaxed dependency on base upper bound to < 5.

### DIFF
--- a/base-unicode-symbols.cabal
+++ b/base-unicode-symbols.cabal
@@ -45,7 +45,7 @@ library
   if flag(old-base)
     build-depends: base >= 3.0 && < 3.0.3.1
   else
-    build-depends: base >= 3.0.3.1 && < 4.6
+    build-depends: base >= 3.0.3.1 && < 5
     exposed-modules: Control.Category.Unicode
   exposed-modules: Control.Applicative.Unicode
                  , Control.Arrow.Unicode


### PR DESCRIPTION
GHC HEAD comes with base-4.6 now. You can go with < 4.7 if you are feeling conservative, but this bumps are getting tedious (trying to build a package that pulls in a lot of dependencies here). I'd appreciate if I didn't have to do this every 4.x release. Also, Edward Kmett [does it](http://hackage.haskell.org/package/semigroups).
